### PR TITLE
Split `access` into `access_mut` and `access` for WriteLock

### DIFF
--- a/demos/cubes/src/main.rs
+++ b/demos/cubes/src/main.rs
@@ -326,7 +326,7 @@ fn main() {
             let mut nodes = node_store.write();
             let levels = level_store.read();
             for cube in cubes.iter_mut() {
-                let node = nodes.access(&cube.node);
+                let node = nodes.access_mut(&cube.node);
                 let level = levels.access(&cube.level);
                 let angle = cgmath::Rad(delta * level.speed);
                 node.local.concat_self(&Space {
@@ -342,15 +342,12 @@ fn main() {
             let mut nodes = node_store.write();
             let mut node_maybe = nodes.first();
             while let Some(node_ptr) = node_maybe {
-                let (local, parent) = {
-                    let n = nodes.access(&node_ptr);
-                    (n.local.clone(), n.parent.clone()) //FIXME
-                };
-                let world = match parent {
-                    Some(parent) => nodes.access(&parent).world.concat(&local),
+                let local = nodes.access(&node_ptr).local;
+                let world = match nodes.access(&node_ptr).parent {
+                    Some(ref parent) => nodes.access(parent).world.concat(&local),
                     None => local,
                 };
-                nodes.access(&node_ptr).world = world;
+                nodes.access_mut(&node_ptr).world = world;
                 node_maybe = nodes.advance(node_ptr);
             }
         }

--- a/examples/iter.rs
+++ b/examples/iter.rs
@@ -19,7 +19,7 @@ fn main() {
             r.pin(&item)
         };
         let mut w = storage.write();
-        *w.access(&ptr) = 350 as i32;
+        *w.access_mut(&ptr) = 350 as i32;
     }
     println!("Array after change:");
     for value in storage.read().iter() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,9 +285,15 @@ impl<'b, 'a, T> Iterator for WriteIter<'b, 'a, T> {
 
 impl<'a, T> WriteLock<'a, T> {
     /// Borrow a pointed component for writing.
-    pub fn access(&mut self, pointer: &Pointer<T>) -> &mut T {
+    pub fn access_mut(&mut self, pointer: &Pointer<T>) -> &mut T {
         debug_assert_eq!(&*self.storage as *const _, &*pointer.target as *const _);
         &mut self.guard.data[pointer.index]
+    }
+
+    /// Borrow a pointed component for reading.
+    pub fn access(&self, pointer: &Pointer<T>) -> &T {
+        debug_assert_eq!(&*self.storage as *const _, &*pointer.target as *const _);
+        &self.guard.data[pointer.index]
     }
 
     /// Iterate all components in this locked storage.


### PR DESCRIPTION
With this change, one can easily access multiple components from the same storage for reading at the same time.
However, you can access only one component for writing at a time.

The problem is, it's a breaking API change, because `access` can not be used for getting `&mut T`. It can be easily solved by renaming `access_mut` back to `access` and `access` to smth like `access_immutable`. But in my opinion it will result in ugly, non-intuitive naming.

The root of the problem isn't here, though. I hope I will make accessing components as simple as in `specs`, with ability to access multiple components for writing. 
It's only temporary fix.