### PR TITLE
Reworked cursor iteration

### DIFF
--- a/demos/cubes/src/main.rs
+++ b/demos/cubes/src/main.rs
@@ -330,9 +330,9 @@ fn main() {
         // re-compute world spaces, using streaming iteration
         {
             let mut cursor = node_store.cursor();
-            while let Some(mut item) = cursor.next() {
+            while let Some((left, mut item, _)) = cursor.next() {
                 item.world = match item.parent {
-                    Some(ref parent) => item.look_back(parent).unwrap().world.concat(&item.local),
+                    Some(ref parent) => left.get(parent).unwrap().world.concat(&item.local),
                     None => item.local,
                 };
             }

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -28,9 +28,9 @@ fn main() {
     // compute them with look-back
     let mut cursor = storage.cursor();
     cursor.next().unwrap(); //skip first
-    while let Some(mut item) = cursor.next() {
+    while let Some((left, mut item, _)) = cursor.next() {
         item.value = item.prev.iter().map(|prev|
-            item.look_back(prev).unwrap().value
+            left.get(prev).unwrap().value
             ).sum();
         println!("{}", item.value);
     }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1,6 +1,38 @@
-use {Cursor, NotFoundError, PendingRef, Pointer, PointerData};
+use {Cursor, PendingRef, Pointer, PointerData};
 use std::marker::PhantomData;
 use std::ops;
+
+
+/// A slice of a storage. Useful for cursor iteration.
+#[derive(Debug)]
+pub struct Slice<'a, T: 'a> {
+    slice: &'a mut [T],
+    offset: usize,
+}
+
+impl<'a, T> Slice<'a, T> {
+    /// Get a reference by pointer. Returns None if an element
+    /// is outside of the slice.
+    pub fn get(&'a self, pointer: &Pointer<T>) -> Option<&'a T> {
+        let index = pointer.data.get_index();
+        if index >= self.offset {
+            self.slice.get(index - self.offset)
+        } else {
+            None
+        }
+    }
+
+    /// Get a mutable reference by pointer. Returns None if an element
+    /// is outside of the slice.
+    pub fn get_mut(&'a mut self, pointer: &Pointer<T>) -> Option<&'a mut T> {
+        let index = pointer.data.get_index();
+        if index >= self.offset {
+            self.slice.get_mut(index - self.offset)
+        } else {
+            None
+        }
+    }
+}
 
 /// Item of the streaming iterator.
 ///
@@ -21,9 +53,7 @@ use std::ops;
 ///
 /// ```
 /// While iterating, you can [`pin`](struct.CursorItem.html#method.pin) item
-/// with Pointer. Also you can [`look_ahead`](struct.CursorItem.html#method.look_ahead)
-/// and [`look_back`](struct.CursorItem.html#method.look_back) for other items
-/// in this storage.
+/// with Pointer.
 ///
 /// ```rust
 /// # use froggy::WeakPointer;
@@ -40,12 +70,12 @@ use std::ops;
 /// # storage[&ptr1].pointer = Some(ptr2.downgrade());
 /// # storage[&ptr2].pointer = Some(ptr1.downgrade());
 /// let mut cursor = storage.cursor();
-/// while let Some(mut item) = cursor.next() {
+/// while let Some((left, mut item, _)) = cursor.next() {
 ///    // let's look for the other Node
 ///    match item.pointer {
 ///        Some(ref pointer) => {
 ///            let ref pointer = pointer.upgrade()?;
-///            if let Ok(ref other_node) = item.look_back(pointer) {
+///            if let Some(ref other_node) = left.get(pointer) {
 ///                do_something(other_node);
 ///            }
 ///        },
@@ -57,7 +87,7 @@ use std::ops;
 /// # fn main() { try_main(); }
 #[derive(Debug)]
 pub struct CursorItem<'a, T: 'a> {
-    slice: &'a mut [T],
+    item: &'a mut T,
     pending: &'a PendingRef,
     data: PointerData,
 }
@@ -65,13 +95,13 @@ pub struct CursorItem<'a, T: 'a> {
 impl<'a, T> ops::Deref for CursorItem<'a, T> {
     type Target = T;
     fn deref(&self) -> &T {
-        unsafe{ self.slice.get_unchecked(self.data.get_index()) }
+        self.item
     }
 }
 
 impl<'a, T> ops::DerefMut for CursorItem<'a, T> {
     fn deref_mut(&mut self) -> &mut T {
-        unsafe{ self.slice.get_unchecked_mut(self.data.get_index()) }
+        self.item
     }
 }
 
@@ -89,85 +119,31 @@ impl<'a, T> CursorItem<'a, T> {
             marker: PhantomData,
         }
     }
-
-    /// Attempt to read an element before the cursor by a pointer.
-    ///
-    /// # Errors
-    /// Returns [`NotFoundError`](struct.NotFoundError.html) if there is no component
-    /// before current `CursorItem` in the `Storage`.
-    pub fn look_back(&self, pointer: &'a Pointer<T>) -> Result<&T, NotFoundError> {
-        debug_assert_eq!(pointer.data.get_storage_id(), self.data.get_storage_id());
-        let id = pointer.data.get_index();
-        if id < self.data.get_index() {
-            Ok(unsafe { self.slice.get_unchecked(id) })
-        } else {
-            Err(NotFoundError)
-        }
-    }
-
-    /// Attempt to mutate an element before the cursor by a pointer.
-    ///
-    /// # Errors
-    /// Returns [`NotFoundError`](struct.NotFoundError.html) if there is no component
-    /// before current `CursorItem` in the `Storage`.
-    pub fn look_back_mut(&mut self, pointer: &'a Pointer<T>) -> Result<&mut T, NotFoundError> {
-        debug_assert_eq!(pointer.data.get_storage_id(), self.data.get_storage_id());
-        let id = pointer.data.get_index();
-        if id < self.data.get_index() {
-            Ok(unsafe { self.slice.get_unchecked_mut(id) })
-        } else {
-            Err(NotFoundError)
-        }
-    }
-
-    /// Attempt to read an element after the cursor by a pointer.
-    ///
-    /// # Errors
-    /// Returns [`NotFoundError`](struct.NotFoundError.html) if there is no component
-    /// after current `CursorItem` in the `Storage`.
-    pub fn look_ahead(&self, pointer: &'a Pointer<T>) -> Result<&T, NotFoundError> {
-        debug_assert_eq!(pointer.data.get_storage_id(), self.data.get_storage_id());
-        let id = pointer.data.get_index();
-        if id > self.data.get_index() {
-            debug_assert!(id < self.slice.len());
-            Ok(unsafe { self.slice.get_unchecked(id) })
-        } else {
-            Err(NotFoundError)
-        }
-    }
-
-    /// Attempt to mutate an element after the cursor by a pointer.
-    ///
-    /// # Errors
-    /// Returns [`NotFoundError`](struct.NotFoundError.html) if there is no component
-    /// after current `CursorItem` in the `Storage`.
-    pub fn look_ahead_mut(&mut self, pointer: &'a Pointer<T>) -> Result<&mut T, NotFoundError> {
-        debug_assert_eq!(pointer.data.get_storage_id(), self.data.get_storage_id());
-        let id = pointer.data.get_index();
-        if id > self.data.get_index() {
-            debug_assert!(id < self.slice.len());
-            Ok(unsafe { self.slice.get_unchecked_mut(id) })
-        } else {
-            Err(NotFoundError)
-        }
-    }
 }
 
 impl<'a, T> Cursor<'a, T> {
     /// Advance the stream to the next item.
-    pub fn next(&mut self) -> Option<CursorItem<T>> {
+    pub fn next(&mut self) -> Option<(Slice<T>, CursorItem<T>, Slice<T>)> {
         loop {
             let id = self.index;
-            if id >= self.storage.data.len() {
-                return None
-            }
             self.index += 1;
-            if !self.skip_lost || unsafe {*self.storage.meta.get_unchecked(id)} != 0 {
-                return Some(CursorItem {
-                    slice: &mut self.storage.data,
-                    data: PointerData::new(id, 0, self.storage_id),
-                    pending: self.pending,
-                })
+            match self.storage.meta.get(id) {
+                None => return None,
+                Some(&0) => (),
+                Some(_) => {
+                    let (left, temp) = self.storage.data.split_at_mut(id);
+                    let (cur, right) = temp.split_at_mut(1);
+                    let item = CursorItem {
+                        item: unsafe { cur.get_unchecked_mut(0) },
+                        data: PointerData::new(id, 0, self.storage_id),
+                        pending: self.pending,
+                    };
+                    return Some((
+                        Slice { slice: left, offset: 0 },
+                        item,
+                        Slice { slice: right, offset: self.index },
+                    ))
+                },
             }
         }
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -78,6 +78,20 @@ fn cursor() {
 }
 
 #[test]
+fn slice() {
+    let mut storage = Storage::new();
+    let a = storage.create(1u32);
+    let b = storage.create(2u32);
+    let c = storage.create(3u32);
+    let (left, mid, right) = storage.split(&b);
+    assert_eq!(*mid, 2);
+    assert_eq!(left.get(&a), Some(&1));
+    assert_eq!(right.get(&c), Some(&3));
+    assert!(left.get(&b).is_none() && left.get(&c).is_none());
+    assert!(right.get(&a).is_none() && right.get(&b).is_none());
+}
+
+#[test]
 fn storage_default() {
     let mut storage = Storage::default();
     storage.create(1u32);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -71,7 +71,7 @@ fn cursor() {
         data.iter().cloned().collect();
     let mut cursor = storage.cursor();
     data.reverse();
-    while let Some(item) = cursor.next() {
+    while let Some((_, item, _)) = cursor.next() {
         assert_eq!(data.pop().as_ref(), Some(&*item));
         let _ptr = item.pin();
     }
@@ -126,7 +126,6 @@ fn test_send() {
     assert_send::<Pointer<i32>>();
     assert_send::<WeakPointer<i32>>();
     assert_send::<froggy::DeadComponentError>();
-    assert_send::<froggy::NotFoundError>();
 }
 
 #[test]
@@ -136,5 +135,4 @@ fn test_sync() {
     assert_sync::<Pointer<i32>>();
     assert_sync::<WeakPointer<i32>>();
     assert_sync::<froggy::DeadComponentError>();
-    assert_sync::<froggy::NotFoundError>();
 }


### PR DESCRIPTION
The problem with current design is that borrow checker doesn't let you mutate the current element *and* lookup front/back at the same time, or do a mutable lookup with anything else.

Solution I propose is to introduce a `Slice` concept, so that each iteration of the `Cursor` produces left/right slices alongside a wrapped current element. This scheme allows changing the front/back items without borrow checker complaints, and is arguably cleaner from the API design POV.