### PR TITLE
Backwards Cursor iteration

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -397,6 +397,18 @@ impl<T> Storage<T> {
         }
     }
 
+    /// Returns a cursor to the end of the storage, for backwards streaming iteration.
+    #[inline]
+    pub fn cursor_end(&mut self) -> Cursor<T> {
+        let total = self.inner.data.len();
+        Cursor {
+            storage: &mut self.inner,
+            pending: &self.pending,
+            index: total,
+            storage_id: self.id,
+        }
+    }
+
     /// Add a new component to the storage, returning the `Pointer` to it.
     pub fn create(&mut self, value: T) -> Pointer<T> {
         let data = match self.inner.free_list.pop() {
@@ -498,5 +510,14 @@ impl<'a, T> Iterator for IterMut<'a, T> {
             self.data.next();
         }
         self.data.next()
+    }
+}
+
+impl<'a, T> DoubleEndedIterator for IterMut<'a, T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        while let Some(&0) = self.meta.next_back() {
+            self.data.next_back();
+        }
+        self.data.next_back()
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -66,14 +66,19 @@ fn weak_epoch() {
 
 #[test]
 fn cursor() {
-    let mut data = vec![5 as i32, 7, 4, 6, 7];
+    let data = vec![5 as i32, 7, 4, 6, 7];
     let mut storage: Storage<_> =
         data.iter().cloned().collect();
+
     let mut cursor = storage.cursor();
-    data.reverse();
+    let mut iter = data.iter();
     while let Some((_, item, _)) = cursor.next() {
-        assert_eq!(data.pop().as_ref(), Some(&*item));
+        assert_eq!(iter.next(), Some(&*item));
         let _ptr = item.pin();
+    }
+
+    while let Some((_, item, _)) = cursor.prev() {
+        assert_eq!(iter.next_back(), Some(&*item));
     }
 }
 


### PR DESCRIPTION
There is never enough power!
Suddenly, I needed to traverse the scenegraph into the reverse order. This is what the new `Cursor::prev` function is addressing.