### PR TITLE
Wake up, froggy, it's 2019!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,22 @@ members = ["demos/cubes"]
 
 [dependencies]
 spin = { version="0.5", default-features=false }
+
+[dev-dependencies]
+criterion = "0.2"
+
+[[bench]]
+name = "ecs_pos_vel_aligned"
+harness = false
+
+[[bench]]
+name = "ecs_pos_vel_spread"
+harness = false
+
+[[bench]]
+name = "sc_graph_aligned"
+harness = false
+
+[[bench]]
+name = "sc_graph_spread"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,4 @@ readme = "README.md"
 members = ["demos/cubes"]
 
 [dependencies]
-spin = { version="0.4", default-features=false }
+spin = { version="0.5", default-features=false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ It aims to combine the convenience of composition-style Object-Oriented Programm
 with the performance close to Entity-Component Systems.
 """
 readme = "README.md"
+edition = "2018"
 
 [workspace]
 members = ["demos/cubes"]

--- a/benches/bench_setup.rs
+++ b/benches/bench_setup.rs
@@ -19,4 +19,3 @@ pub struct Velocity {
     pub dy: f32,
     pub writes: Pointer<Position>,
 }
-

--- a/benches/bench_setup.rs
+++ b/benches/bench_setup.rs
@@ -1,5 +1,3 @@
-extern crate froggy;
-
 use froggy::Pointer;
 
 /// Entities with velocity and position component.

--- a/benches/ecs_pos_vel_aligned.rs
+++ b/benches/ecs_pos_vel_aligned.rs
@@ -1,10 +1,5 @@
-#![feature(test)]
-
-extern crate froggy;
-extern crate test;
-
+use criterion::{criterion_group, criterion_main, Criterion};
 use froggy::{Pointer, Storage};
-use test::Bencher;
 
 mod bench_setup;
 use bench_setup::{Position, N_POS, N_POS_VEL};
@@ -53,23 +48,26 @@ fn build() -> World {
     world
 }
 
-#[bench]
-fn bench_build(b: &mut Bencher) {
-    b.iter(build);
+fn bench_build(c: &mut Criterion) {
+    c.bench_function("build-ecs-aligned", |b| b.iter(|| build()));
 }
 
-#[bench]
-fn bench_update(b: &mut Bencher) {
+fn bench_update(c: &mut Criterion) {
     let mut world = build();
 
-    b.iter(|| {
-        for e in &world.entities {
-            if let Some(ref vel) = e.vel {
-                let mut p = &mut world.pos[&e.pos];
-                let v = &world.vel[vel];
-                p.x += v.dx;
-                p.y += v.dy;
+    c.bench_function("update-ecs-aligned", move |b| {
+        b.iter(|| {
+            for e in &world.entities {
+                if let Some(ref vel) = e.vel {
+                    let mut p = &mut world.pos[&e.pos];
+                    let v = &world.vel[vel];
+                    p.x += v.dx;
+                    p.y += v.dy;
+                }
             }
-        }
+        })
     });
 }
+
+criterion_group!(benches, bench_build, bench_update);
+criterion_main!(benches);

--- a/benches/ecs_pos_vel_aligned.rs
+++ b/benches/ecs_pos_vel_aligned.rs
@@ -1,13 +1,13 @@
 #![feature(test)]
 
-extern crate test;
 extern crate froggy;
+extern crate test;
 
-use test::Bencher;
 use froggy::{Pointer, Storage};
+use test::Bencher;
 
 mod bench_setup;
-use bench_setup::{Position, N_POS_VEL, N_POS};
+use bench_setup::{Position, N_POS, N_POS_VEL};
 
 // Since component linking is not used in this bench,
 // it has a custom Velocity component
@@ -36,13 +36,13 @@ fn build() -> World {
 
     // setup entities
     {
-        for _ in 0 .. N_POS_VEL {
+        for _ in 0..N_POS_VEL {
             world.entities.push(Entity {
                 pos: world.pos.create(Position { x: 0.0, y: 0.0 }),
                 vel: Some(world.vel.create(Velocity { dx: 0.0, dy: 0.0 })),
             });
         }
-        for _ in 0 .. N_POS {
+        for _ in 0..N_POS {
             world.entities.push(Entity {
                 pos: world.pos.create(Position { x: 0.0, y: 0.0 }),
                 vel: None,

--- a/benches/ecs_pos_vel_spread.rs
+++ b/benches/ecs_pos_vel_spread.rs
@@ -1,10 +1,5 @@
-#![feature(test)]
-
-extern crate froggy;
-extern crate test;
-
+use criterion::{criterion_group, criterion_main, Criterion};
 use froggy::{Pointer, Storage};
-use test::Bencher;
 
 mod bench_setup;
 use bench_setup::{Position, N_POS, N_POS_VEL};
@@ -55,23 +50,26 @@ fn build() -> World {
     world
 }
 
-#[bench]
-fn bench_build(b: &mut Bencher) {
-    b.iter(build);
+fn bench_build(c: &mut Criterion) {
+    c.bench_function("build-ecs-spread", |b| b.iter(|| build()));
 }
 
-#[bench]
-fn bench_update(b: &mut Bencher) {
+fn bench_update(c: &mut Criterion) {
     let mut world = build();
 
-    b.iter(|| {
-        for e in &world.entities {
-            if let Some(ref vel) = e.vel {
-                let mut p = &mut world.pos[&e.pos];
-                let v = &world.vel[vel];
-                p.x += v.dx;
-                p.y += v.dy;
+    c.bench_function("update-ecs-spread", move |b| {
+        b.iter(|| {
+            for e in &world.entities {
+                if let Some(ref vel) = e.vel {
+                    let mut p = &mut world.pos[&e.pos];
+                    let v = &world.vel[vel];
+                    p.x += v.dx;
+                    p.y += v.dy;
+                }
             }
-        }
+        })
     });
 }
+
+criterion_group!(benches, bench_build, bench_update);
+criterion_main!(benches);

--- a/benches/ecs_pos_vel_spread.rs
+++ b/benches/ecs_pos_vel_spread.rs
@@ -1,13 +1,13 @@
 #![feature(test)]
 
-extern crate test;
 extern crate froggy;
+extern crate test;
 
-use test::Bencher;
 use froggy::{Pointer, Storage};
+use test::Bencher;
 
 mod bench_setup;
-use bench_setup::{Position, N_POS_VEL, N_POS};
+use bench_setup::{Position, N_POS, N_POS_VEL};
 
 // Since component linking is not used in this bench,
 // it has a custom Velocity component
@@ -38,19 +38,17 @@ fn build() -> World {
     {
         let pos_spread = (N_POS + N_POS_VEL) / N_POS_VEL;
 
-        for fx in 1 .. (N_POS_VEL + N_POS + 1) {
+        for fx in 1..(N_POS_VEL + N_POS + 1) {
             world.entities.push(Entity {
                 pos: world.pos.create(Position { x: 0.0, y: 0.0 }),
                 vel: None,
-
             });
             if fx % pos_spread == 0 {
                 world.entities.push(Entity {
-                pos: world.pos.create(Position { x: 0.0, y: 0.0 }),
-                vel: Some(world.vel.create(Velocity { dx: 0.0, dy: 0.0 })),
+                    pos: world.pos.create(Position { x: 0.0, y: 0.0 }),
+                    vel: Some(world.vel.create(Velocity { dx: 0.0, dy: 0.0 })),
                 });
             }
-
         }
     }
 

--- a/benches/sc_graph_aligned.rs
+++ b/benches/sc_graph_aligned.rs
@@ -1,10 +1,5 @@
-#![feature(test)]
-
-extern crate froggy;
-extern crate test;
-
+use criterion::{criterion_group, criterion_main, Criterion};
 use froggy::{Pointer, Storage};
-use test::Bencher;
 
 mod bench_setup;
 use bench_setup::{Position, Velocity, N_POS, N_POS_VEL};
@@ -47,20 +42,23 @@ fn build() -> World {
     world
 }
 
-#[bench]
-fn bench_build(b: &mut Bencher) {
-    b.iter(build);
+fn bench_build(c: &mut Criterion) {
+    c.bench_function("build-graph-aligned", |b| b.iter(|| build()));
 }
 
-#[bench]
-fn bench_update(b: &mut Bencher) {
+fn bench_update(c: &mut Criterion) {
     let mut world = build();
 
-    b.iter(|| {
-        for vel in world.vel.iter() {
-            let mut p = &mut world.pos[&vel.writes];
-            p.x += vel.dx;
-            p.y += vel.dy;
-        }
+    c.bench_function("update-graph-aligned", move |b| {
+        b.iter(|| {
+            for vel in world.vel.iter() {
+                let mut p = &mut world.pos[&vel.writes];
+                p.x += vel.dx;
+                p.y += vel.dy;
+            }
+        })
     });
 }
+
+criterion_group!(benches, bench_build, bench_update);
+criterion_main!(benches);

--- a/benches/sc_graph_aligned.rs
+++ b/benches/sc_graph_aligned.rs
@@ -1,16 +1,16 @@
 #![feature(test)]
 
-extern crate test;
 extern crate froggy;
+extern crate test;
 
-use test::Bencher;
 use froggy::{Pointer, Storage};
+use test::Bencher;
 
 mod bench_setup;
-use bench_setup::{Position, Velocity, N_POS_VEL, N_POS};
+use bench_setup::{Position, Velocity, N_POS, N_POS_VEL};
 
 struct Movement {
-	pub vel_comp: Vec<Pointer<Velocity>>,
+    pub vel_comp: Vec<Pointer<Velocity>>,
 }
 
 struct World {
@@ -20,22 +20,26 @@ struct World {
 }
 
 fn build() -> World {
-
     let mut world = World {
         pos: Storage::with_capacity(N_POS_VEL + N_POS),
         vel: Storage::with_capacity(N_POS_VEL),
-        movement: Movement{ vel_comp: Vec::new() },
+        movement: Movement {
+            vel_comp: Vec::new(),
+        },
     };
 
-
     {
-        for _ in 0 .. N_POS_VEL {
+        for _ in 0..N_POS_VEL {
             let pos_ptr = world.pos.create(Position { x: 0.0, y: 0.0 });
-	    	let v = Velocity { dx: 0.0, dy: 0.0, writes: pos_ptr};
-	        world.movement.vel_comp.push(world.vel.create(v));
+            let v = Velocity {
+                dx: 0.0,
+                dy: 0.0,
+                writes: pos_ptr,
+            };
+            world.movement.vel_comp.push(world.vel.create(v));
         }
 
-        for _ in 0 .. N_POS {
+        for _ in 0..N_POS {
             world.pos.create(Position { x: 0.0, y: 0.0 });
         }
     }

--- a/benches/sc_graph_spread.rs
+++ b/benches/sc_graph_spread.rs
@@ -1,10 +1,5 @@
-#![feature(test)]
-
-extern crate froggy;
-extern crate test;
-
+use criterion::{criterion_group, criterion_main, Criterion};
 use froggy::{Pointer, Storage};
-use test::Bencher;
 
 mod bench_setup;
 use bench_setup::{Position, Velocity, N_POS, N_POS_VEL};
@@ -48,20 +43,23 @@ fn build() -> World {
     world
 }
 
-#[bench]
-fn bench_build(b: &mut Bencher) {
-    b.iter(build);
+fn bench_build(c: &mut Criterion) {
+    c.bench_function("build-graph-spread", |b| b.iter(|| build()));
 }
 
-#[bench]
-fn bench_update(b: &mut Bencher) {
+fn bench_update(c: &mut Criterion) {
     let mut world = build();
 
-    b.iter(|| {
-        for vel in world.vel.iter() {
-            let mut p = &mut world.pos[&vel.writes];
-            p.x += vel.dx;
-            p.y += vel.dy;
-        }
+    c.bench_function("update-graph-spread", move |b| {
+        b.iter(|| {
+            for vel in world.vel.iter() {
+                let mut p = &mut world.pos[&vel.writes];
+                p.x += vel.dx;
+                p.y += vel.dy;
+            }
+        })
     });
 }
+
+criterion_group!(benches, bench_build, bench_update);
+criterion_main!(benches);

--- a/benches/sc_graph_spread.rs
+++ b/benches/sc_graph_spread.rs
@@ -1,16 +1,16 @@
 #![feature(test)]
 
-extern crate test;
 extern crate froggy;
+extern crate test;
 
-use test::Bencher;
 use froggy::{Pointer, Storage};
+use test::Bencher;
 
 mod bench_setup;
-use bench_setup::{Position, Velocity, N_POS_VEL, N_POS};
+use bench_setup::{Position, Velocity, N_POS, N_POS_VEL};
 
 struct Movement {
-	pub vel_comp: Vec<Pointer<Velocity>>,
+    pub vel_comp: Vec<Pointer<Velocity>>,
 }
 
 struct World {
@@ -20,24 +20,28 @@ struct World {
 }
 
 fn build() -> World {
-
     let mut world = World {
         pos: Storage::with_capacity(N_POS_VEL + N_POS),
         vel: Storage::with_capacity(N_POS_VEL),
-        movement: Movement{ vel_comp: Vec::new() },
+        movement: Movement {
+            vel_comp: Vec::new(),
+        },
     };
-
 
     {
         let pos_spread = (N_POS + N_POS_VEL) / N_POS_VEL;
 
-        for fx in 1 .. (N_POS_VEL + N_POS + 1) {
+        for fx in 1..(N_POS_VEL + N_POS + 1) {
             let pos_ptr = world.pos.create(Position { x: 0.0, y: 0.0 });
 
-    	    if fx % pos_spread == 0 {
-    	        let v = Velocity { dx: 0.0, dy: 0.0, writes: pos_ptr};
-    	        world.movement.vel_comp.push(world.vel.create(v));
-    	    }
+            if fx % pos_spread == 0 {
+                let v = Velocity {
+                    dx: 0.0,
+                    dy: 0.0,
+                    writes: pos_ptr,
+                };
+                world.movement.vel_comp.push(world.vel.create(v));
+            }
         }
     }
 

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -17,7 +17,7 @@ fn main() {
         value: 0,
     });
     // initialize the other ones
-    for _ in 0 .. 10 {
+    for _ in 0..10 {
         let next = storage.create(Fibbo {
             prev: vec![first, second.clone()],
             value: 0,
@@ -29,9 +29,11 @@ fn main() {
     let mut cursor = storage.cursor();
     cursor.next().unwrap(); //skip first
     while let Some((left, mut item, _)) = cursor.next() {
-        item.value = item.prev.iter().map(|prev|
-            left.get(prev).unwrap().value
-            ).sum();
+        item.value = item
+            .prev
+            .iter()
+            .map(|prev| left.get(prev).unwrap().value)
+            .sum();
         println!("{}", item.value);
     }
 }

--- a/examples/iter.rs
+++ b/examples/iter.rs
@@ -4,16 +4,16 @@ fn main() {
     let mut storage: froggy::Storage<i32> =
         [5, 7, 4, 6, 7].iter().cloned().collect();
     println!("Initial array:");
-    for value in storage.iter() {
+    for value in storage.iter_all() {
         println!("Value {}", *value);
     }
     let ptr = {
-        let item = storage.iter().find(|v| **v == 4).unwrap();
+        let item = storage.iter_all().find(|v| **v == 4).unwrap();
         storage.pin(&item)
     };
     storage[&ptr] = 350;
     println!("Array after change:");
-    for value in &storage {
+    for value in storage.iter_all() {
         println!("Value {}", *value);
     }
 }

--- a/examples/iter.rs
+++ b/examples/iter.rs
@@ -1,8 +1,7 @@
 extern crate froggy;
 
 fn main() {
-    let mut storage: froggy::Storage<i32> =
-        [5, 7, 4, 6, 7].iter().cloned().collect();
+    let mut storage: froggy::Storage<i32> = [5, 7, 4, 6, 7].iter().cloned().collect();
     println!("Initial array:");
     for value in storage.iter_all() {
         println!("Value {}", *value);

--- a/examples/iter.rs
+++ b/examples/iter.rs
@@ -2,7 +2,7 @@ extern crate froggy;
 
 fn main() {
     let mut storage: froggy::Storage<i32> =
-        [5 as i32, 7, 4, 6, 7].iter().cloned().collect();
+        [5, 7, 4, 6, 7].iter().cloned().collect();
     println!("Initial array:");
     for value in storage.iter() {
         println!("Value {}", *value);
@@ -11,7 +11,7 @@ fn main() {
         let item = storage.iter().find(|v| **v == 4).unwrap();
         storage.pin(&item)
     };
-    storage[&ptr] = 350 as i32;
+    storage[&ptr] = 350;
     println!("Array after change:");
     for value in &storage {
         println!("Value {}", *value);

--- a/src/bitfield.rs
+++ b/src/bitfield.rs
@@ -27,8 +27,11 @@ impl PointerData {
     #[inline]
     pub fn new(index: Index, epoch: Epoch, storage: StorageId) -> Self {
         debug_assert_eq!(index >> INDEX_BITS, 0);
-        PointerData(index as u64 + ((u64::from(epoch)) << EPOCH_OFFSET) +
-            ((u64::from(storage)) << STORAGE_ID_OFFSET))
+        PointerData(
+            index as u64
+                + ((u64::from(epoch)) << EPOCH_OFFSET)
+                + ((u64::from(storage)) << STORAGE_ID_OFFSET),
+        )
     }
 
     #[inline]

--- a/src/bitfield.rs
+++ b/src/bitfield.rs
@@ -1,4 +1,4 @@
-use {Epoch, Index, StorageId};
+use crate::{Epoch, Index, StorageId};
 
 #[derive(Copy, Clone, Debug, PartialEq, Hash)]
 pub struct PointerData(u64);

--- a/src/bitfield.rs
+++ b/src/bitfield.rs
@@ -27,28 +27,28 @@ impl PointerData {
     #[inline]
     pub fn new(index: Index, epoch: Epoch, storage: StorageId) -> Self {
         debug_assert_eq!(index >> INDEX_BITS, 0);
-        PointerData(index as u64 + ((epoch as u64) << EPOCH_OFFSET) +
-            ((storage as u64) << STORAGE_ID_OFFSET))
+        PointerData(index as u64 + ((u64::from(epoch)) << EPOCH_OFFSET) +
+            ((u64::from(storage)) << STORAGE_ID_OFFSET))
     }
 
     #[inline]
-    pub fn get_index(&self) -> Index {
+    pub fn get_index(self) -> Index {
         (self.0 & INDEX_MASK) as Index
     }
 
     #[inline]
-    pub fn get_epoch(&self) -> Epoch {
+    pub fn get_epoch(self) -> Epoch {
         ((self.0 & EPOCH_MASK) >> EPOCH_OFFSET) as Epoch
     }
 
     #[inline]
-    pub fn get_storage_id(&self) -> StorageId {
+    pub fn get_storage_id(self) -> StorageId {
         ((self.0 & STORAGE_ID_MASK) >> STORAGE_ID_OFFSET) as StorageId
     }
 
     #[inline]
-    pub fn with_epoch(&self, epoch: Epoch) -> PointerData {
-        PointerData((self.0 & !EPOCH_MASK) + ((epoch as u64) << EPOCH_OFFSET))
+    pub fn with_epoch(self, epoch: Epoch) -> PointerData {
+        PointerData((self.0 & !EPOCH_MASK) + ((u64::from(epoch)) << EPOCH_OFFSET))
     }
 }
 

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1,6 +1,6 @@
+use crate::{Cursor, PendingRef, Pointer, PointerData, Slice};
 use std::marker::PhantomData;
 use std::ops;
-use {Cursor, PendingRef, Pointer, PointerData, Slice};
 
 impl<'a, T> Slice<'a, T> {
     /// Check if the slice contains no elements.

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1,7 +1,6 @@
-use {Cursor, PendingRef, Pointer, PointerData, Slice};
 use std::marker::PhantomData;
 use std::ops;
-
+use {Cursor, PendingRef, Pointer, PointerData, Slice};
 
 impl<'a, T> Slice<'a, T> {
     /// Check if the slice contains no elements.
@@ -13,7 +12,10 @@ impl<'a, T> Slice<'a, T> {
     /// is outside of the slice.
     pub fn get(&'a self, pointer: &Pointer<T>) -> Option<&'a T> {
         debug_assert_eq!(pointer.data.get_storage_id(), self.offset.get_storage_id());
-        let index = pointer.data.get_index().wrapping_sub(self.offset.get_index());
+        let index = pointer
+            .data
+            .get_index()
+            .wrapping_sub(self.offset.get_index());
         self.slice.get(index as usize)
     }
 
@@ -21,7 +23,10 @@ impl<'a, T> Slice<'a, T> {
     /// is outside of the slice.
     pub fn get_mut(&'a mut self, pointer: &Pointer<T>) -> Option<&'a mut T> {
         debug_assert_eq!(pointer.data.get_storage_id(), self.offset.get_storage_id());
-        let index = pointer.data.get_index().wrapping_sub(self.offset.get_index());
+        let index = pointer
+            .data
+            .get_index()
+            .wrapping_sub(self.offset.get_index());
         self.slice.get_mut(index as usize)
     }
 }
@@ -118,7 +123,8 @@ impl<'a, T> Cursor<'a, T> {
         let data = PointerData::new(index, 0, self.storage_id);
         let (left, item, right) = self.storage.split(data);
         let item = CursorItem {
-            item, data,
+            item,
+            data,
             pending: self.pending,
         };
         (left, item, right)
@@ -133,7 +139,7 @@ impl<'a, T> Cursor<'a, T> {
                 None => {
                     self.index = id; // prevent the bump of the index
                     return None;
-                },
+                }
                 Some(&0) => (),
                 Some(_) => return Some(self.split(id)),
             }
@@ -144,7 +150,7 @@ impl<'a, T> Cursor<'a, T> {
     pub fn prev(&mut self) -> Option<(Slice<T>, CursorItem<T>, Slice<T>)> {
         loop {
             if self.index == 0 {
-                return None
+                return None;
             }
             self.index -= 1;
             let id = self.index;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,24 +21,27 @@ However, CGS has a number of advantages:
 #![warn(missing_docs)]
 #![doc(html_root_url = "https://docs.rs/froggy/0.4.4")]
 
-extern crate spin;
-
 mod bitfield;
 mod cursor;
 mod weak;
 
-use bitfield::PointerData;
+use crate::bitfield::PointerData;
 use spin::Mutex;
-use std::hash::{Hash, Hasher};
-use std::iter::FromIterator;
-use std::marker::PhantomData;
-use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
-use std::sync::Arc;
-use std::vec::Drain;
-use std::{fmt, ops, slice};
+use std::{
+    fmt,
+    hash::{Hash, Hasher},
+    iter::FromIterator,
+    marker::PhantomData,
+    ops, slice,
+    sync::{
+        atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT},
+        Arc,
+    },
+    vec::Drain,
+};
 
-pub use cursor::CursorItem;
-pub use weak::WeakPointer;
+pub use crate::cursor::CursorItem;
+pub use crate::weak::WeakPointer;
 
 type Index = usize;
 
@@ -175,7 +178,7 @@ impl<T> fmt::Debug for Pointer<T> {
         }
 
         fmt::Debug::fmt(
-            Pointer {
+            &Pointer {
                 index: self.data.get_index() as usize,
                 epoch: self.data.get_epoch() as usize,
                 storage_id: self.data.get_storage_id() as usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,14 +290,14 @@ impl<T> Storage<T> {
         let uid = STORAGE_UID.fetch_add(1, Ordering::Relaxed) as StorageId;
         Storage {
             inner: StorageInner {
-                data: data,
-                meta: meta,
+                data,
+                meta,
                 free_list: Vec::new(),
             },
             pending: Arc::new(Mutex::new(Pending {
                 add_ref: Vec::new(),
                 sub_ref: Vec::new(),
-                epoch: epoch,
+                epoch,
             })),
             id: uid,
         }
@@ -462,7 +462,7 @@ impl<T> Storage<T> {
             },
         };
         Pointer {
-            data: data,
+            data,
             pending: self.pending.clone(),
             marker: PhantomData,
         }

--- a/src/weak.rs
+++ b/src/weak.rs
@@ -1,5 +1,5 @@
 use std::marker::PhantomData;
-use {Pointer, PointerData, PendingRef, DeadComponentError};
+use {DeadComponentError, PendingRef, Pointer, PointerData};
 
 /// Weak variant of `Pointer`.
 /// `WeakPointer`s are used to avoid deadlocking when dropping structures with cycled references to each other.

--- a/src/weak.rs
+++ b/src/weak.rs
@@ -1,5 +1,5 @@
+use crate::{DeadComponentError, PendingRef, Pointer, PointerData};
 use std::marker::PhantomData;
-use {DeadComponentError, PendingRef, Pointer, PointerData};
 
 /// Weak variant of `Pointer`.
 /// `WeakPointer`s are used to avoid deadlocking when dropping structures with cycled references to each other.

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -24,8 +24,7 @@ fn change_by_pointer() {
 
 #[test]
 fn iterating() {
-    let storage: Storage<_> =
-        [5 as i32, 7, 4, 6, 7].iter().cloned().collect();
+    let storage: Storage<_> = [5 as i32, 7, 4, 6, 7].iter().cloned().collect();
     assert_eq!(storage.iter_all().count(), 5);
     assert_eq!(*storage.iter_all().nth(0).unwrap(), 5);
     assert_eq!(*storage.iter_all().nth(1).unwrap(), 7);
@@ -34,7 +33,7 @@ fn iterating() {
 
 #[test]
 fn iter_zombies() {
-    let storage: Storage<_> = (0 .. 5).map(|i| i*3 as i32).collect();
+    let storage: Storage<_> = (0..5).map(|i| i * 3 as i32).collect();
     assert_eq!(storage.iter().count(), 0);
     assert_eq!(storage.iter_all().count(), 5);
 }
@@ -67,8 +66,7 @@ fn weak_epoch() {
 #[test]
 fn cursor() {
     let data = vec![5 as i32, 7, 4, 6, 7];
-    let mut storage: Storage<_> =
-        data.iter().cloned().collect();
+    let mut storage: Storage<_> = data.iter().cloned().collect();
 
     let mut cursor = storage.cursor();
     let mut iter = data.iter();

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,5 +1,3 @@
-extern crate froggy;
-
 use froggy::{Pointer, Storage, WeakPointer};
 
 #[test]


### PR DESCRIPTION
It's been a long time for froggy and I think it's a good chance to update everything and prepare for solving remaining issues.

Includes:
- Update of spin dependency 0.4 -> 0.5
- Slight clean-up of `iter` example, as well as fixing it (it didn't work at all)
- Fix some clippy issue in bitfield module
- Using latest rustfmt and translation to Rust 2018
- Benchmarks are now using Criterion and no more depend on nightly.

Unfortunately, I can't run cubes demo, so it might be broken.